### PR TITLE
Allow .github directory modifications via PRs from destination repo

### DIFF
--- a/project/copy.bara.sky
+++ b/project/copy.bara.sky
@@ -14,11 +14,11 @@ PUSH_EXCLUDE = [PROJECT_DIR + "/copy.bara.sky"]
 
 # what can be read in the destination PR
 PR_ORIGIN_INCLUDE = ["**"]
-PR_ORIGIN_EXCLUDE = [".github/**"]
+PR_ORIGIN_EXCLUDE = []
 
 # what can be modified in SoT repo via PR
 PR_DESTINATION_INCLUDE = [PROJECT_DIR + "/**"]
-PR_DESTINATION_EXCLUDE = [PROJECT_DIR + "/copy.bara.sky", PROJECT_DIR + "/.github/**"]
+PR_DESTINATION_EXCLUDE = [PROJECT_DIR + "/copy.bara.sky"]
 
 # Push workflow: monorepo to public repo
 core.workflow(
@@ -63,7 +63,7 @@ core.workflow(
     origin_files = glob(PR_ORIGIN_INCLUDE, exclude = PR_ORIGIN_EXCLUDE),
     destination_files = glob(PR_DESTINATION_INCLUDE, exclude = PR_DESTINATION_EXCLUDE),
     transformations = [
-        core.move("", PROJECT_DIR, paths = glob(["**"], exclude = [".github/**"])),
+        core.move("", PROJECT_DIR),
         metadata.replace_message("${GITHUB_PR_TITLE}\n\n${GITHUB_PR_BODY}\n\n--\n\n"),
         metadata.expose_label("GITHUB_PR_URL", "Closes", separator=": "),
         metadata.save_author("Original-author", separator=": "),


### PR DESCRIPTION
## Summary
This PR enables contributors to modify GitHub workflows and configurations in the destination repository through pull requests. These modifications will be properly synced back to the SoT repository under `project/.github/`.

## Changes
- Remove `.github/**` from `PR_ORIGIN_EXCLUDE` to allow reading .github files from destination PRs
- Remove `PROJECT_DIR/.github/**` from `PR_DESTINATION_EXCLUDE` to allow writing to project/.github in SoT
- Remove `.github/**` exclusion from the move transformation in PR workflow

## Why this is safe
The change maintains clear separation between:
- **SoT `.github/`** - Contains sync infrastructure workflows (mirror-to-public, import-public-pr, etc.)
  - Never synced to destination
  - Protected from any modifications
- **SoT `project/.github/`** - Contains destination repository's workflows
  - Bidirectionally synced with destination's `.github/`
  - Can now be modified via PRs

## What this enables
✅ Contributors can now:
- Modify destination repository workflows
- Update GitHub Actions configurations
- Add/modify dependabot, codeowners, etc.
- All changes properly tracked in SoT

## Testing
- Configuration validated with `copybara validate`
- No conflicts possible due to directory separation

Co-Authored-By: Claude <noreply@anthropic.com>