### PR TITLE
[EXT] Update README to clarify PR synchronization behavior

### DIFF
--- a/project/.github/workflows/ci.yml
+++ b/project/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: CI
 
 on:
-  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -11,8 +12,10 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: npm

--- a/project/.github/workflows/pr-notify.yml
+++ b/project/.github/workflows/pr-notify.yml
@@ -3,8 +3,6 @@ name: PR notify
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, edited]
-    paths-ignore:
-      - '.github/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -13,7 +11,9 @@ concurrency:
 jobs:
   notify:
     runs-on: ubuntu-latest
-    if: github.repository == 'stepankuzmin/copybara-dst'
+    if: |
+      github.repository == 'stepankuzmin/copybara-dst' &&
+      github.event.pull_request.base.ref == github.event.repository.default_branch
     steps:
       - name: Notify upstream
         uses: actions/github-script@v7

--- a/project/README.md
+++ b/project/README.md
@@ -8,5 +8,5 @@ The repository uses Google's [Copybara](https://github.com/google/copybara/) to 
 
 Please see the [upstream README.md](https://github.com/stepankuzmin/copybara-sot/tree/main?tab=readme-ov-file) for more details.
 
-Every PR in this repository will be automatically synchronized to the upstream repository.
+PRs targeting the default branch in this repository will be automatically synchronized to the upstream repository.
 After changes land upstream, they're automatically propagated back to this repository! 🚀


### PR DESCRIPTION
## Summary
- Updated README.md to clarify that only PRs targeting the default branch will be synchronized to upstream

## Context
Following the recent workflow update that restricts PR notifications to only trigger for PRs targeting the default branch, this updates the documentation to match the actual behavior.

--

> [!NOTE]
> This PR was imported from https://github.com/stepankuzmin/copybara-dst/pull/22
> ```
> <public>Update README to clarify PR synchronization behavior (h/t @stepankuzmin) #22</public>
> ```

Closes: https://github.com/stepankuzmin/copybara-dst/pull/22
Original-author: Stepan Kuzmin <533564+stepankuzmin@users.noreply.github.com>
