### PR TITLE
[EXT] Set required Node version to 22

### DIFF
--- a/project/package.json
+++ b/project/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "type": "module",
   "main": "index.js",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "test": "node --test --experimental-strip-types",
     "tsc": "tsc"


### PR DESCRIPTION
We use `--experimental-strip-types` which was added in Node v22

--

> [!NOTE]
> This PR was imported from https://github.com/stepankuzmin/copybara-dst/pull/25
> ```
> <public>
> Set required Node version to 22 (h/t @stepankuzmin) (public-25)
> </public>
> ```

Closes: https://github.com/stepankuzmin/copybara-dst/pull/25
Author: Stepan Kuzmin <533564+stepankuzmin@users.noreply.github.com>
